### PR TITLE
Implement GlowMapRenderer.render()

### DIFF
--- a/src/main/java/net/glowstone/block/BuiltinMaterialValueManager.java
+++ b/src/main/java/net/glowstone/block/BuiltinMaterialValueManager.java
@@ -89,5 +89,9 @@ public class BuiltinMaterialValueManager implements MaterialValueManager {
         public double getSlipperiness() {
             return 0.6;
         }
+
+        @Override public byte getBaseMapColor() {
+            return ((Number) get("baseMapColor")).byteValue();
+        }
     }
 }

--- a/src/main/java/net/glowstone/block/MaterialValueManager.java
+++ b/src/main/java/net/glowstone/block/MaterialValueManager.java
@@ -58,5 +58,11 @@ public interface MaterialValueManager {
          * @return the slipperiness
          */
         double getSlipperiness();
+
+        /**
+         * Returns the base map color for this value. Map pixels with this as the highest block can
+         * be this value plus 0 to 3.
+         */
+        byte getBaseMapColor();
     }
 }

--- a/src/main/java/net/glowstone/map/GlowMapRenderer.java
+++ b/src/main/java/net/glowstone/map/GlowMapRenderer.java
@@ -1,9 +1,15 @@
 package net.glowstone.map;
 
+import static net.glowstone.map.GlowMapCanvas.MAP_SIZE;
+
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.map.MapCanvas;
 import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
+import org.bukkit.material.MaterialData;
 
 /**
  * Glowstone's built-in map renderer.
@@ -19,7 +25,61 @@ public final class GlowMapRenderer extends MapRenderer {
 
     @Override
     public void render(MapView map, MapCanvas canvas, Player player) {
-        // todo
+        World world = map.getWorld();
+        int scaleShift = map.getScale().getValue();
+        for (int pixelX = 0; pixelX < MAP_SIZE; pixelX++) {
+            for (int pixelY = 0; pixelY < MAP_SIZE; pixelY++) {
+                int worldX = map.getCenterX() + (pixelX - MAP_SIZE/2) << scaleShift;
+                int worldZ = map.getCenterZ() + (pixelY - MAP_SIZE/2) << scaleShift;
+                byte blockColor = colorFor(world.getHighestBlockAt(worldX, worldZ),
+                    worldX, worldZ);
+                canvas.setPixel(pixelX, pixelY, blockColor);
+            }
+        }
     }
 
+    private static byte pseudoRandomShade(int worldX, int worldZ) {
+        return (byte) ((
+                ((worldX * worldX * 0x4c1906) + (worldX * 0x5ac0db) + ((worldZ * worldZ) * 0x4307a7)
+                + (worldZ * 0x5f24f))) % 4);
+    }
+    private static byte colorFor(Block block, int worldX, int worldZ) {
+        byte base_color;
+        switch (block.getType()) {
+            case GRASS:
+            case LONG_GRASS:
+                base_color = 4;
+                break;
+            case SAND:
+            case SANDSTONE:
+            case SANDSTONE_STAIRS:
+                base_color = 8;
+                break;
+            case HUGE_MUSHROOM_1:
+                base_color = (byte) (isMushroomStem(block.getData()) ? 12 : 40);
+                break;
+            case HUGE_MUSHROOM_2:
+                base_color = (byte) (isMushroomStem(block.getData()) ? 12 : 28);
+                break;
+            case STONE:
+            case COBBLESTONE:
+            case COBBLESTONE_STAIRS:
+            case MOSSY_COBBLESTONE:
+            case STONE_SLAB2:
+            case DOUBLE_STONE_SLAB2:
+                base_color = 44;
+                break;
+            case WATER:
+                base_color = 48;
+                break;
+            // TODO: Add all the other materials
+            default:
+                base_color = 0;
+        }
+        return (byte) (base_color | pseudoRandomShade(worldX, worldZ));
+    }
+
+    private static boolean isMushroomStem(byte data) {
+        return data == 10 || data == 15;
+    }
 }

--- a/src/main/java/net/glowstone/map/GlowMapRenderer.java
+++ b/src/main/java/net/glowstone/map/GlowMapRenderer.java
@@ -2,20 +2,24 @@ package net.glowstone.map;
 
 import static net.glowstone.map.GlowMapCanvas.MAP_SIZE;
 
-import org.bukkit.Material;
+import net.glowstone.GlowServer;
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.MaterialValueManager.ValueCollection;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.map.MapCanvas;
 import org.bukkit.map.MapRenderer;
 import org.bukkit.map.MapView;
-import org.bukkit.material.MaterialData;
 
 /**
  * Glowstone's built-in map renderer.
  */
 public final class GlowMapRenderer extends MapRenderer {
 
+    private static final int MAP_SIGHT_DISTANCE_SQUARED = 64*64;
     private final GlowMapView map;
 
     public GlowMapRenderer(GlowMapView map) {
@@ -27,59 +31,42 @@ public final class GlowMapRenderer extends MapRenderer {
     public void render(MapView map, MapCanvas canvas, Player player) {
         World world = map.getWorld();
         int scaleShift = map.getScale().getValue();
+        Location playerLoc = player.getLocation();
+        int playerX = playerLoc.getBlockX();
+        int playerZ = playerLoc.getBlockZ();
         for (int pixelX = 0; pixelX < MAP_SIZE; pixelX++) {
             for (int pixelY = 0; pixelY < MAP_SIZE; pixelY++) {
                 int worldX = map.getCenterX() + (pixelX - MAP_SIZE/2) << scaleShift;
                 int worldZ = map.getCenterZ() + (pixelY - MAP_SIZE/2) << scaleShift;
-                byte blockColor = colorFor(world.getHighestBlockAt(worldX, worldZ),
-                    worldX, worldZ);
-                canvas.setPixel(pixelX, pixelY, blockColor);
+                if (((worldX - playerX)*(worldX - playerX) + (worldZ - playerZ)*(worldZ - playerZ)) <
+                        MAP_SIGHT_DISTANCE_SQUARED) {
+                    // TODO: Should the highest block be skipped over if it's e.g. a flower or a
+                    // technical block?
+                    byte blockColor =
+                        colorFor(world.getHighestBlockAt(worldX, worldZ), worldX, worldZ);
+                    canvas.setPixel(pixelX, pixelY, blockColor);
+                }
             }
         }
     }
 
+    /**
+     * Based on https://minecraft.gamepedia.com/Slime#.22Slime_chunks.22 but simplified (doesn't
+     * instantiate a Random, and doesn't vary with the world seed. Designed to be reproducible, so
+     * that updating a map doesn't change the color unless the map contents have changed.
+     */
     private static byte pseudoRandomShade(int worldX, int worldZ) {
         return (byte) ((
                 ((worldX * worldX * 0x4c1906) + (worldX * 0x5ac0db) + ((worldZ * worldZ) * 0x4307a7)
                 + (worldZ * 0x5f24f))) % 4);
     }
     private static byte colorFor(Block block, int worldX, int worldZ) {
-        byte base_color;
-        switch (block.getType()) {
-            case GRASS:
-            case LONG_GRASS:
-                base_color = 4;
-                break;
-            case SAND:
-            case SANDSTONE:
-            case SANDSTONE_STAIRS:
-                base_color = 8;
-                break;
-            case HUGE_MUSHROOM_1:
-                base_color = (byte) (isMushroomStem(block.getData()) ? 12 : 40);
-                break;
-            case HUGE_MUSHROOM_2:
-                base_color = (byte) (isMushroomStem(block.getData()) ? 12 : 28);
-                break;
-            case STONE:
-            case COBBLESTONE:
-            case COBBLESTONE_STAIRS:
-            case MOSSY_COBBLESTONE:
-            case STONE_SLAB2:
-            case DOUBLE_STONE_SLAB2:
-                base_color = 44;
-                break;
-            case WATER:
-                base_color = 48;
-                break;
-            // TODO: Add all the other materials
-            default:
-                base_color = 0;
-        }
+        // TODO: Some blocks vary in map color based on block states (e.g. wood species)
+        ValueCollection materialValues;
+        materialValues = block instanceof GlowBlock ? ((GlowBlock) block).getMaterialValues()
+            : ((GlowServer) Bukkit.getServer()).getMaterialValueManager()
+                .getValues(block.getType());
+        byte base_color = materialValues.getBaseMapColor();
         return (byte) (base_color | pseudoRandomShade(worldX, worldZ));
-    }
-
-    private static boolean isMushroomStem(byte data) {
-        return data == 10 || data == 15;
     }
 }

--- a/src/main/resources/builtin/materialValues.yml
+++ b/src/main/resources/builtin/materialValues.yml
@@ -4,21 +4,28 @@ default:
   lightOpacity: 255
   flameResistance: -1
   fireResistance: -1
+  baseMapColor: 44
 values:
+  # TODO: Define baseMapColor for all materials
   AIR:
     lightOpacity: 0
+    baseMapColor: 0
   STONE:
     blastResistance: 30
     hardness: 1.5
+    baseMapColor: 44
   GRASS:
     blastResistance: 3
     hardness: 0.6
+    baseMapColor: 4
   DIRT:
     blastResistance: 2.5
     hardness: 0.5
+    baseMapColor: 40
   COBBLESTONE:
     blastResistance: 30
     hardness: 2
+    baseMapColor: 44
   WOOD:
     flameResistance: 5
     fireResistance: 20
@@ -34,6 +41,7 @@ values:
     lightOpacity: 3
     hardness: 100
     blastResistance: 500
+    baseMapColor: 48
   STATIONARY_WATER:
     lightOpacity: 3
     hardness: 100


### PR DESCRIPTION
This implementation is basic -- it only considers the material value of the highest block at each pixel -- but it implements the limited vision range and is configurable in YAML. Someone may still need to implement persistence for the GlowMapCanvas.