### PR TITLE
Allow fields named x, y or z, per existing practice

### DIFF
--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -202,7 +202,7 @@
     </module>
     <module name="MemberName">
       <property name="severity" value="warning"/> <!-- TODO: fix naming capitalization -->
-      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+      <property name="format" value="^([a-z][a-z0-9][a-zA-Z0-9]*|[xyz])$"/>
       <message key="name.invalidPattern" value="Member name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="ParameterName">


### PR DESCRIPTION
The Block*Message classes already use these names for world coordinates, so why prohibit people from following the convention?