### PR TITLE
Bug fix: exception in TallGrassDecorator if there's an empty column in overworld

### DIFF
--- a/src/main/java/net/glowstone/generator/decorators/overworld/TallGrassDecorator.java
+++ b/src/main/java/net/glowstone/generator/decorators/overworld/TallGrassDecorator.java
@@ -20,7 +20,12 @@ public class TallGrassDecorator extends BlockDecorator {
     public void decorate(World world, Random random, Chunk source) {
         int sourceX = (source.getX() << 4) + random.nextInt(16);
         int sourceZ = (source.getZ() << 4) + random.nextInt(16);
-        int sourceY = random.nextInt(Math.abs(world.getHighestBlockYAt(sourceX, sourceZ) << 1));
+        int topBlock = world.getHighestBlockYAt(sourceX, sourceZ);
+        if (topBlock == 0) {
+            // Nothing to do if this column is empty
+            return;
+        }
+        int sourceY = random.nextInt(Math.abs(topBlock << 1));
 
         // the grass species can change on each decoration pass
         GrassSpecies species = GrassSpecies.NORMAL;


### PR DESCRIPTION
Can happen in the Void superflat preset, as well as certain other presets (e.g. a single solid layer with villages, since the gravel roads will generate in that layer and fall into the void). Was observed as a side effect of https://github.com/GlowstoneMC/Glowstone/issues/630